### PR TITLE
Add profile/team integration and unread message badges

### DIFF
--- a/backend/database/migrations/005_chat_system.sql
+++ b/backend/database/migrations/005_chat_system.sql
@@ -7,6 +7,15 @@ CREATE TABLE chat_messages (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE chat_read_status (
+    id SERIAL PRIMARY KEY,
+    team_id INTEGER REFERENCES teams(id) ON DELETE CASCADE,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    last_read_message_id INTEGER REFERENCES chat_messages(id) ON DELETE SET NULL,
+    last_read_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(team_id, user_id)
+);
+
 CREATE TABLE chat_reactions (
     id SERIAL PRIMARY KEY,
     message_id INTEGER REFERENCES chat_messages(id) ON DELETE CASCADE,
@@ -28,6 +37,8 @@ CREATE INDEX idx_chat_messages_team_id ON chat_messages(team_id);
 CREATE INDEX idx_chat_messages_created_at ON chat_messages(created_at);
 CREATE INDEX idx_chat_reactions_message_id ON chat_reactions(message_id);
 CREATE INDEX idx_chat_typing_team_id ON chat_typing(team_id);
+CREATE INDEX idx_chat_read_status_team_user ON chat_read_status(team_id, user_id);
+CREATE INDEX idx_chat_read_status_message_id ON chat_read_status(last_read_message_id);
 
 CREATE OR REPLACE FUNCTION cleanup_old_typing()
 RETURNS void AS $$

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -190,12 +190,29 @@ export const getProfile: RequestHandler = async (
       }
 
       const userRow = userResult.rows[0];
+
+      const teamQuery = `
+        SELECT t.id, t.name, t.color, tm.role
+        FROM team_members tm
+        JOIN teams t ON tm.team_id = t.id
+        WHERE tm.user_id = $1 AND t.is_active = true
+      `;
+      const teamResult = await client.query(teamQuery, [user.id]);
+
+      const currentTeam = teamResult.rows.length > 0 ? {
+        id: teamResult.rows[0].id,
+        name: teamResult.rows[0].name,
+        color: teamResult.rows[0].color,
+        role: teamResult.rows[0].role
+      } : null;
+
       return res.json({
         id: userRow.id,
         username: userRow.username,
         email: userRow.email,
         firstName: userRow.first_name,
         lastName: userRow.last_name,
+        currentTeam
       });
     } finally {
       client.release();

--- a/backend/src/routes/chat.ts
+++ b/backend/src/routes/chat.ts
@@ -22,4 +22,10 @@ router.post('/messages/:messageId/reactions', [
   body('emoji').isIn(['👍', '❤️', '😂', '😮', '😢', '😡'])
 ], chatController.addReaction);
 
+router.post('/messages/read', [
+  body('messageId').isInt({ min: 1 })
+], chatController.markAsRead);
+
+router.get('/unread-count', chatController.getUnreadCount);
+
 export default router;

--- a/mobile/src/api/chatService.ts
+++ b/mobile/src/api/chatService.ts
@@ -43,4 +43,19 @@ export const chatService = {
     );
     return data;
   },
+
+  async markAsRead(messageId: number) {
+    const { data } = await api.post<{ success: boolean }>(
+      "/chat/messages/read",
+      { messageId }
+    );
+    return data;
+  },
+
+  async getUnreadCount() {
+    const { data } = await api.get<{ unreadCount: number }>(
+      "/chat/unread-count"
+    );
+    return data;
+  },
 };

--- a/mobile/src/components/TabBarBadge.tsx
+++ b/mobile/src/components/TabBarBadge.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { theme } from '../theme/theme';
+
+interface TabBarBadgeProps {
+  count: number;
+  visible?: boolean;
+}
+
+export const TabBarBadge: React.FC<TabBarBadgeProps> = ({ count, visible = true }) => {
+  if (!visible || count === 0) {
+    return null;
+  }
+
+  const displayText = count > 10 ? '+10' : count.toString();
+
+  return (
+    <View style={styles.badge}>
+      <Text style={styles.badgeText}>{displayText}</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    top: -6,
+    right: -6,
+    backgroundColor: '#FF3B30',
+    borderRadius: 10,
+    minWidth: 20,
+    height: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 6,
+  },
+  badgeText: {
+    color: theme.colors.white,
+    fontSize: 12,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+});

--- a/mobile/src/navigation/MainNavigator.tsx
+++ b/mobile/src/navigation/MainNavigator.tsx
@@ -1,17 +1,22 @@
 import { Ionicons } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import React from "react";
+import { View } from "react-native";
 import { MapScreen } from "../screens/MapScreen";
 import { ProfileScreen } from "../screens/ProfileScreen";
 import { RunScreen } from "../screens/RunScreen";
 import { TeamScreen } from "../screens/TeamScreen";
 import { ChatScreen } from "../screens/ChatScreen";
+import { TabBarBadge } from "../components/TabBarBadge";
+import { useChatStore } from "../store/chatStore";
 import { theme } from "../theme/theme";
 import { RootStackParamList } from "./types";
 
 const Tab = createBottomTabNavigator<RootStackParamList>();
 
 export const MainNavigator = () => {
+  const { unreadCount } = useChatStore();
+
   return (
     <Tab.Navigator
       screenOptions={{
@@ -64,7 +69,10 @@ export const MainNavigator = () => {
         component={ChatScreen}
         options={{
           tabBarIcon: ({ color, size }) => (
-            <Ionicons name="chatbubbles" size={size} color={color} />
+            <View>
+              <Ionicons name="chatbubbles" size={size} color={color} />
+              <TabBarBadge count={unreadCount} />
+            </View>
           ),
         }}
       />

--- a/mobile/src/store/authStore.ts
+++ b/mobile/src/store/authStore.ts
@@ -5,6 +5,14 @@ interface User {
   id: string;
   email: string;
   username: string;
+  firstName?: string;
+  lastName?: string;
+  currentTeam?: {
+    id: string;
+    name: string;
+    color: string;
+    role: string;
+  } | null;
 }
 
 interface AuthState {

--- a/mobile/src/store/chatStore.ts
+++ b/mobile/src/store/chatStore.ts
@@ -6,6 +6,7 @@ interface ChatState {
   isLoading: boolean;
   error: string | null;
   typingUsers: string[];
+  unreadCount: number;
   
   fetchMessages: () => Promise<void>;
   sendMessage: (message: string) => Promise<void>;
@@ -13,6 +14,9 @@ interface ChatState {
   addMessage: (message: ChatMessage) => void;
   updateReactions: (messageId: number, reactions: any[]) => void;
   setTypingUsers: (users: string[]) => void;
+  markAsRead: (messageId: number) => Promise<void>;
+  fetchUnreadCount: () => Promise<void>;
+  setUnreadCount: (count: number) => void;
   clearError: () => void;
 }
 
@@ -21,6 +25,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   isLoading: false,
   error: null,
   typingUsers: [],
+  unreadCount: 0,
 
   fetchMessages: async () => {
     set({ isLoading: true, error: null });
@@ -72,6 +77,29 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
   setTypingUsers: (users: string[]) => {
     set({ typingUsers: users });
+  },
+
+  markAsRead: async (messageId: number) => {
+    try {
+      await chatService.markAsRead(messageId);
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Failed to mark as read",
+      });
+    }
+  },
+
+  fetchUnreadCount: async () => {
+    try {
+      const { unreadCount } = await chatService.getUnreadCount();
+      set({ unreadCount });
+    } catch (error) {
+      console.error('Failed to fetch unread count:', error);
+    }
+  },
+
+  setUnreadCount: (count: number) => {
+    set({ unreadCount: count });
   },
 
   clearError: () => {


### PR DESCRIPTION
- Update profile endpoint to include current team data
- Add unread message tracking with chat_read_status table
- Create TabBarBadge component for navigation
- Add unread count API endpoints and mobile integration
- Update ChatScreen to mark messages as read
- Integrate team data in auth store
- Display message count up to 10, show '+10' for more